### PR TITLE
feat: initial implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM grafana/agent:v0.26.1
+
+# Set environment variables
+ARG PROMETHEUS_PUSH_USERNAME
+ARG PROMETHEUS_PUSH_PASSWORD
+
+# Expose the port for access
+EXPOSE 8000/tcp
+
+# Copy configuration file
+COPY ./grafana_agent/config.yaml /etc/agent/agent.yaml
+
+# Provide configuration file and set environment variables from container env
+CMD ["--config.file=/etc/agent/agent.yaml", "--server.http.address=0.0.0.0:8000", "--config.expand-env"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# web3.storage telemetry
+# web3.storage telemetry-grafana-agent
+
+Telemetry grafana agent to scrape metrics endpoints and push them to a given Grafana Cloud endpoint.
+
+## Deployment
+
+This is automatically deployed into a Digital Ocean App once commits make it to #main.

--- a/grafana_agent/config.yaml
+++ b/grafana_agent/config.yaml
@@ -10,9 +10,12 @@ prometheus:
     - name: local
       host_filter: false
       scrape_configs:
-        - job_name: cloudflare-analytics-edge-gateway
+        - job_name: edge-gateway-cloudflare-analytics
           static_configs:
             - targets: ['edge-gateway-cf-zone-analytics.dag.haus']
+        - job_name: edge-gateway-superhot
+          static_configs:
+            - targets: ['api.nftstorage.link']
       remote_write:
         - url: ${PROMETHEUS_PUSH_URL}
           basic_auth:

--- a/grafana_agent/config.yaml
+++ b/grafana_agent/config.yaml
@@ -1,0 +1,20 @@
+server:
+  log_level: debug
+
+prometheus:
+  global:
+    scrape_interval: 5m
+    external_labels:
+      scraped_by: grafana-agent
+  configs:
+    - name: local
+      host_filter: false
+      scrape_configs:
+        - job_name: cloudflare-analytics-edge-gateway
+          static_configs:
+            - targets: ['edge-gateway-cf-zone-analytics.dag.haus']
+      remote_write:
+        - url: ${PROMETHEUS_PUSH_URL}
+          basic_auth:
+            username: ${PROMETHEUS_PUSH_USERNAME}
+            password: ${PROMETHEUS_PUSH_PASSWORD}


### PR DESCRIPTION
This PR sets up a Grafana Agent to push metrics into our Prometheus instance in DAG House Grafana cloud.

It includes scrapping target `edge-gateway-cf-zone-analytics.dag.haus` for our metrics.

Repo currently setup into our Digital Ocean account with needed env vars, deploying on each commit to #main

Closes https://github.com/web3-storage/reads/issues/26